### PR TITLE
fix: move index_prefix under indices key for Jaeger v2

### DIFF
--- a/apps/eniac/jaeger.yaml
+++ b/apps/eniac/jaeger.yaml
@@ -62,7 +62,8 @@ spec:
               elasticsearch:
                 server_urls:
                   - http://jaeger-es-http.monitoring.svc.cluster.local:9200
-                index_prefix: jaeger
+                indices:
+                  index_prefix: jaeger
         jaeger_query:
           base_path: /jaeger
           storage:


### PR DESCRIPTION
## Summary
Fixes Jaeger pod crash: `'elasticsearch' has invalid keys: index_prefix`

In Jaeger v2, `index_prefix` moved from a top-level elasticsearch config key to being nested under `indices:`.

## Test plan
- [ ] Jaeger pod starts without config errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)