### PR TITLE
fix: configure healthcheckv2 endpoint and path for liveness probes

### DIFF
--- a/apps/eniac/jaeger.yaml
+++ b/apps/eniac/jaeger.yaml
@@ -55,7 +55,10 @@ spec:
       extensions:
         healthcheckv2:
           use_v2: true
-          http: {}
+          http:
+            endpoint: 0.0.0.0:13133
+            status:
+              path: /status
         jaeger_storage:
           backends:
             primary_store:


### PR DESCRIPTION
## Summary
Jaeger pod was being killed by liveness probes. The chart probes `http://:13133/status` but the `healthcheckv2` extension was configured with `http: {}` which defaults to serving on `/`, not `/status`.

Configures explicit endpoint (`0.0.0.0:13133`) and status path (`/status`) to match.

## Test plan
- [ ] Jaeger pod passes liveness and readiness probes
- [ ] Pod reaches Ready state

🤖 Generated with [Claude Code](https://claude.com/claude-code)