### PR TITLE
fix: add controller field to plex service for app-template v4

### DIFF
--- a/apps/eniac/plex.yaml
+++ b/apps/eniac/plex.yaml
@@ -43,6 +43,7 @@ spec:
             fsGroupChangePolicy: "OnRootMismatch"
     service:
       main:
+        controller: main
         type: LoadBalancer
         loadBalancerIP: 192.168.50.205
         annotations:


### PR DESCRIPTION
## Summary
- Adds back the `controller: main` field to the Plex service definition
- The upgrade from app-template v3 to v4 (#186) mistakenly removed this field
- In app-template v4, services must explicitly declare their controller since there is no longer a default primary controller concept
- Without this field, the service is not linked to the controller, causing `ERR_CONNECTION_CLOSED` when accessing plex.home.gawbul.io

## Test plan
- [ ] Verify FluxCD reconciles the change
- [ ] Confirm plex.home.gawbul.io loads successfully in the browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)