### PR TITLE
feat: add ingress for ollama deployment

### DIFF
--- a/apps/eniac/ollama.yaml
+++ b/apps/eniac/ollama.yaml
@@ -42,9 +42,27 @@ spec:
             fsGroup: 1000
     service:
       main:
+        controller: main
         ports:
           http:
             port: 11434
+    ingress:
+      main:
+        enabled: true
+        className: traefik
+        annotations:
+          cert-manager.io/cluster-issuer: letsencrypt
+        hosts:
+          - host: ollama.home.gawbul.io
+            paths:
+              - path: /
+                service:
+                  identifier: main
+                  port: http
+        tls:
+          - hosts:
+              - ollama.home.gawbul.io
+            secretName: ollama-tls
     persistence:
       models:
         enabled: true


### PR DESCRIPTION
## Summary
- Add Traefik ingress with Let's Encrypt TLS to expose Ollama at `ollama.home.gawbul.io`
- Add missing `controller: main` field to the service block for app-template v4 compatibility
- TLS certificate managed via cert-manager with `ollama-tls` secret

## Test plan
- [ ] Verify FluxCD reconciles the updated HelmRelease successfully
- [ ] Confirm `ollama.home.gawbul.io` resolves to the Traefik ingress IP (via DNS/Pi-hole)
- [ ] Verify TLS certificate is issued by Let's Encrypt
- [ ] Test Ollama API access via `curl https://ollama.home.gawbul.io`

🤖 Generated with [Claude Code](https://claude.com/claude-code)