### PR TITLE
feat: increase Ollama CPU and memory resources for RPi 5 16GB

### DIFF
--- a/apps/eniac/ollama.yaml
+++ b/apps/eniac/ollama.yaml
@@ -32,11 +32,11 @@ spec:
               OLLAMA_KEEP_ALIVE: "24h"
             resources:
               requests:
-                cpu: 2000m
-                memory: 8Gi
+                cpu: 4000m
+                memory: 12Gi
               limits:
-                cpu: 2000m
-                memory: 8Gi
+                cpu: 4000m
+                memory: 12Gi
         pod:
           securityContext:
             fsGroup: 1000


### PR DESCRIPTION
## Summary
- Increase Ollama CPU requests/limits from 2000m to 4000m (all 4 RPi 5 cores)
- Increase Ollama memory requests/limits from 8Gi to 12Gi (~75% of 16GB)
- Maintains Guaranteed QoS class with equal requests and limits

## Test plan
- [ ] Verify FluxCD reconciles the updated HelmRelease
- [ ] Confirm Ollama pod starts with new resource allocations
- [ ] Test LLM inference performance with increased resources
- [ ] Monitor node resource usage to ensure other workloads are not starved

🤖 Generated with [Claude Code](https://claude.com/claude-code)