### PR TITLE
fix: reduce Ollama CPU to 3000m for node schedulability

### DIFF
--- a/apps/eniac/ollama.yaml
+++ b/apps/eniac/ollama.yaml
@@ -32,10 +32,10 @@ spec:
               OLLAMA_KEEP_ALIVE: "24h"
             resources:
               requests:
-                cpu: 4000m
+                cpu: 3000m
                 memory: 12Gi
               limits:
-                cpu: 4000m
+                cpu: 3000m
                 memory: 12Gi
         pod:
           securityContext:


### PR DESCRIPTION
## Summary
- Reduce Ollama CPU requests/limits from 4000m to 3000m
- 4000m exceeded allocatable CPU on the RPi 5 node (Kubernetes reserves CPU for system components), causing `FailedScheduling`
- Memory remains at 12Gi, QoS class stays Guaranteed

## Test plan
- [ ] Verify pod schedules successfully on the `workload=ai` node
- [ ] Confirm Ollama starts and serves inference requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)