### PR TITLE
feat: switch Ollama model from llama3.2 to llama3.1

### DIFF
--- a/apps/eniac/ollama.yaml
+++ b/apps/eniac/ollama.yaml
@@ -75,7 +75,7 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: pull-llama3-2
+  name: pull-llama3-1
   namespace: media
   annotations:
     "helm.sh/hook": post-install,post-upgrade
@@ -91,5 +91,5 @@ spec:
             - "POST"
             - "http://ollama.media.svc.cluster.local:11434/api/pull"
             - "-d"
-            - '{"name": "llama3.2"}'
+            - '{"name": "llama3.1"}'
       restartPolicy: OnFailure


### PR DESCRIPTION
## Summary
- Switch Ollama pull job from llama3.2 to llama3.1 model
- Update job name to match the new model version

## Test plan
- [ ] Verify FluxCD reconciles the updated HelmRelease successfully
- [ ] Confirm the pull job pulls the llama3.1 model after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)