### PR TITLE
feat: change default Ollama model to llama3.1

### DIFF
--- a/apps/eniac/ollama.yaml
+++ b/apps/eniac/ollama.yaml
@@ -75,7 +75,7 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: pull-llama3-2
+  name: pull-llama3-1
   namespace: media
   annotations:
     "helm.sh/hook": post-install,post-upgrade
@@ -91,5 +91,5 @@ spec:
             - "POST"
             - "http://ollama.media.svc.cluster.local:11434/api/pull"
             - "-d"
-            - '{"name": "llama3.2"}'
+            - '{"name": "llama3.1"}'
       restartPolicy: OnFailure


### PR DESCRIPTION
## Summary
- Change the default Ollama model pull from llama3.2 to llama3.1
- Updates both the Job name and the model name in the curl payload

## Test plan
- [ ] Verify FluxCD reconciles the updated Job successfully
- [ ] Confirm llama3.1 is pulled on next Ollama post-install/post-upgrade hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)