### PR TITLE
feat: add AIOStreams Stremio addon aggregator

### DIFF
--- a/apps/eniac/aiostreams-secret.yaml
+++ b/apps/eniac/aiostreams-secret.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: aiostreams-secret
+    namespace: media
+type: Opaque
+stringData:
+    FORCED_REALDEBRID_API_KEY: ENC[AES256_GCM,data:NxmZg4WOD4qHpwga6Cpi3oODCXgDuR7O3b6VMDFKzBnqNN9hJ+NXe8058UPvA78nXokgPQ==,iv:nL51tGUAc153PPIKOJcoX8cURh2DGBCFujYkNVevQFw=,tag:UNmgc1hTqbUcK1etumjBcg==,type:str]
+sops:
+    age:
+        - recipient: age1hvmdhkt8llkq3m00ullewwgycy2ujr8tlhqk6ley07usyexcq9vsz8mymh
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA4TUd0MDdtSHYxUytrTTBD
+            TysreThOM2lvNitPanZ0OEVCeG1lWVFxNHlNCkpCcVFBSGlvc21iQUo2TTdSZEtE
+            ZExYOTUySWdJbVBLNUUzVFdGQkI1VU0KLS0tIDhBSFBkQVF0K2dGRjUvV0hEaExO
+            SmFlNGg3QURUK3k2NzlKak1DZGFiNHMKHyplfulHbyxTmpJLHKJJXT66jmMvCOhm
+            SZeow/nsQ7soqqpVaG50okNYMzoD166rUD2o5yHNgLo0L6stHorHPA==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-04-12T09:48:36Z"
+    mac: ENC[AES256_GCM,data:cgV7bBALokP3ujssmI3r9FIclMKoZFvCdxlVzNsqbe6O2yF7mhz64CIDs2AMsTL1oD7BgemwD6EiNT3cYEgmPsw+Igl9A0yvJeZzIMoIVrBkpP1/ngIpDr86lN935K8qOUYbB6SlBqTX+n0Ye9UTbH3Kl21IWS3kB2GO8d0oTHM=,iv:Lnx2YWKKzC481DkOSMZD4FeVjQGY2w87WK8DkjTq4Ig=,tag:6MMirbmOxg9BqenlPD6OJA==,type:str]
+    encrypted_regex: ^(data|stringData)$
+    version: 3.12.2

--- a/apps/eniac/aiostreams.yaml
+++ b/apps/eniac/aiostreams.yaml
@@ -1,0 +1,62 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: aiostreams
+  namespace: media
+spec:
+  interval: 5m
+  chart:
+    spec:
+      chart: app-template
+      version: 4.6.2
+      sourceRef:
+        kind: HelmRepository
+        name: bjw-s-labs
+        namespace: media
+  values:
+    controllers:
+      main:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          main:
+            image:
+              repository: ghcr.io/viren070/aiostreams
+              tag: latest
+            env:
+              TZ: Europe/London
+              BASE_URL: https://aiostreams.home.gawbul.io
+            envFrom:
+              - secretRef:
+                  name: aiostreams-secret
+    service:
+      main:
+        ports:
+          http:
+            port: 3000
+    ingress:
+      main:
+        enabled: true
+        className: traefik
+        annotations:
+          cert-manager.io/cluster-issuer: letsencrypt
+        hosts:
+          - host: aiostreams.home.gawbul.io
+            paths:
+              - path: /
+                service:
+                  identifier: main
+                  port: http
+        tls:
+          - hosts:
+              - aiostreams.home.gawbul.io
+            secretName: aiostreams-tls
+    persistence:
+      data:
+        enabled: true
+        storageClass: local-path
+        accessMode: ReadWriteOnce
+        size: 2Gi
+        globalMounts:
+          - path: /app/data

--- a/apps/eniac/kustomization.yaml
+++ b/apps/eniac/kustomization.yaml
@@ -24,3 +24,5 @@ resources:
   - recommendarr.yaml
   - plex-secret.yaml
   - plex.yaml
+  - aiostreams-secret.yaml
+  - aiostreams.yaml


### PR DESCRIPTION
## Summary
- Adds AIOStreams (Stremio addon aggregator) deployment to the media namespace
- Uses bjw-s app-template with Traefik ingress and Let's Encrypt TLS at `aiostreams.home.gawbul.io`
- Includes SOPS-encrypted Real Debrid API key and persistent storage for SQLite DB

## Test plan
- [ ] Verify FluxCD reconciles the new HelmRelease successfully
- [ ] Confirm the pod starts and is healthy on port 3000
- [ ] Check ingress is accessible at `https://aiostreams.home.gawbul.io`
- [ ] Verify the configure UI loads at `/stremio/configure`
- [ ] Confirm Real Debrid is available as a debrid service option

🤖 Generated with [Claude Code](https://claude.com/claude-code)