### PR TITLE
fix: add SECRET_KEY to AIOStreams secret

### DIFF
--- a/apps/eniac/aiostreams-secret.yaml
+++ b/apps/eniac/aiostreams-secret.yaml
@@ -5,19 +5,20 @@ metadata:
     namespace: media
 type: Opaque
 stringData:
-    FORCED_REALDEBRID_API_KEY: ENC[AES256_GCM,data:NxmZg4WOD4qHpwga6Cpi3oODCXgDuR7O3b6VMDFKzBnqNN9hJ+NXe8058UPvA78nXokgPQ==,iv:nL51tGUAc153PPIKOJcoX8cURh2DGBCFujYkNVevQFw=,tag:UNmgc1hTqbUcK1etumjBcg==,type:str]
+    SECRET_KEY: ENC[AES256_GCM,data:Y3hXHLV8m9dDZ/9L4w1XI73h4/AFtLSvZZy2Rfa/BlPYFDoMsVVvyCciRxjTTGOj76kFXSDBma544cH6ZmSYcg==,iv:Lum71nTw8QPGUWwRyYmHCFtNhrz20Fh7jJWwOw9kwWw=,tag:Mu7zeqFpPEeUt0UIwQAdNQ==,type:str]
+    FORCED_REALDEBRID_API_KEY: ENC[AES256_GCM,data:8H/Yf5YSMS6YeKtWsUoDRrru5zgkMa+GSfuUoErI+cRymTcwGW+8yZMjjv/A+uWF324WYg==,iv:5tLjQtj5TH9LFm3eAseEwzm6uWTFvVSNvX2ENYu8i3w=,tag:cmxI9lluwVZfFJswBe7B0g==,type:str]
 sops:
     age:
         - recipient: age1hvmdhkt8llkq3m00ullewwgycy2ujr8tlhqk6ley07usyexcq9vsz8mymh
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA4TUd0MDdtSHYxUytrTTBD
-            TysreThOM2lvNitPanZ0OEVCeG1lWVFxNHlNCkpCcVFBSGlvc21iQUo2TTdSZEtE
-            ZExYOTUySWdJbVBLNUUzVFdGQkI1VU0KLS0tIDhBSFBkQVF0K2dGRjUvV0hEaExO
-            SmFlNGg3QURUK3k2NzlKak1DZGFiNHMKHyplfulHbyxTmpJLHKJJXT66jmMvCOhm
-            SZeow/nsQ7soqqpVaG50okNYMzoD166rUD2o5yHNgLo0L6stHorHPA==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBVTUh3cjMvTUhkZzRYNHBH
+            Q2RUZkREeTAwOFVhU21kOU5TbGM3bGhjVlY0CmdHOUxJaEJ4d1orV1F4djM4bnR1
+            OUlsVXFKME9vY2JlR1hpYXl3bnpDQWMKLS0tIDNMYnVWSHRKTXFjOHU0Q3pnS21s
+            dmhDNlprSS81eS9RSjlHZVd3cHhMVlEKRHR7Mh9INymcyKuOdjFwDsxjvkj5bNk1
+            6KKrBTPdvlR9X6o0HaRiYEp5mVQnGOoTQxkHryE3d3kTVZQH/NxROQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-04-12T09:48:36Z"
-    mac: ENC[AES256_GCM,data:cgV7bBALokP3ujssmI3r9FIclMKoZFvCdxlVzNsqbe6O2yF7mhz64CIDs2AMsTL1oD7BgemwD6EiNT3cYEgmPsw+Igl9A0yvJeZzIMoIVrBkpP1/ngIpDr86lN935K8qOUYbB6SlBqTX+n0Ye9UTbH3Kl21IWS3kB2GO8d0oTHM=,iv:Lnx2YWKKzC481DkOSMZD4FeVjQGY2w87WK8DkjTq4Ig=,tag:6MMirbmOxg9BqenlPD6OJA==,type:str]
+    lastmodified: "2026-04-12T09:56:55Z"
+    mac: ENC[AES256_GCM,data:0wYO/C6hRv+Kp1x6pdyET1hQU9b1Y4zqkHkgoNjeMFxLbXg1skC2mPmukaiMvZwpbTfLGX2KZ0QbL0QcVm1zg9GhB0OYPnPGnWzJVTTpQxTdj7snXTUjiQC3PuuoeAwXGx44/Uf1h+NRLtVCMe6QjEdAvohywPk+LEbgmVx9ghg=,iv:nLZo65LD2sAJJl1I9CqR6ABNTqS9th5EBTXphJvacnA=,tag:NgK02F9Ed2CA8PfPAzTuZQ==,type:str]
     encrypted_regex: ^(data|stringData)$
     version: 3.12.2


### PR DESCRIPTION
## Summary
- Adds required `SECRET_KEY` (64-char hex) to the AIOStreams SOPS-encrypted secret
- Without this the container exits immediately on startup with a missing env var error

## Test plan
- [ ] Verify the AIOStreams pod starts successfully without the missing SECRET_KEY error
- [ ] Confirm the configure UI is accessible at `https://aiostreams.home.gawbul.io/stremio/configure`

🤖 Generated with [Claude Code](https://claude.com/claude-code)