### PR TITLE
fix: set AIOStreams ADDON_ID to self-hosted domain

### DIFF
--- a/apps/eniac/aiostreams.yaml
+++ b/apps/eniac/aiostreams.yaml
@@ -27,6 +27,7 @@ spec:
             env:
               TZ: Europe/London
               BASE_URL: https://aiostreams.home.gawbul.io
+              ADDON_ID: aiostreams.home.gawbul.io
             envFrom:
               - secretRef:
                   name: aiostreams-secret


### PR DESCRIPTION
## Summary
- Sets `ADDON_ID` to `aiostreams.home.gawbul.io` instead of the upstream default `aiostreams.viren070.com`

## Test plan
- [ ] Verify the pod restarts with the new env var
- [ ] Confirm the addon registers with the correct ID in Stremio

🤖 Generated with [Claude Code](https://claude.com/claude-code)