### PR TITLE
feat: add Premiumize API key to AIOStreams

### DIFF
--- a/apps/eniac/aiostreams-secret.yaml
+++ b/apps/eniac/aiostreams-secret.yaml
@@ -5,20 +5,21 @@ metadata:
     namespace: media
 type: Opaque
 stringData:
-    SECRET_KEY: ENC[AES256_GCM,data:Y3hXHLV8m9dDZ/9L4w1XI73h4/AFtLSvZZy2Rfa/BlPYFDoMsVVvyCciRxjTTGOj76kFXSDBma544cH6ZmSYcg==,iv:Lum71nTw8QPGUWwRyYmHCFtNhrz20Fh7jJWwOw9kwWw=,tag:Mu7zeqFpPEeUt0UIwQAdNQ==,type:str]
-    FORCED_REALDEBRID_API_KEY: ENC[AES256_GCM,data:8H/Yf5YSMS6YeKtWsUoDRrru5zgkMa+GSfuUoErI+cRymTcwGW+8yZMjjv/A+uWF324WYg==,iv:5tLjQtj5TH9LFm3eAseEwzm6uWTFvVSNvX2ENYu8i3w=,tag:cmxI9lluwVZfFJswBe7B0g==,type:str]
+    SECRET_KEY: ENC[AES256_GCM,data:sdFrfgAZXr5OehGPzsER5JbXx7DyZ9lfskxU2Um0UZ9MkWfox79bZ2FVqqr3aUstfptR4L38pJVpqVIUHKS1Rw==,iv:pD9Bq0P4OAa3pRnmC4AHnCXErKq+PoBI/tu8DaJrOlU=,tag:3Sgu0i7GEhwICS5y+Apt+Q==,type:str]
+    FORCED_REALDEBRID_API_KEY: ENC[AES256_GCM,data:6MhaImh316hYau7CCtezlylhtzj9fWq5TIqICY7T2ikdNMsDwoQGHE7hlKJH4aRLvkYdQw==,iv:K7uDNlgpScUddqxHNmn9esFQ1EenJ6nBiPSX+hqbvfY=,tag:9hFWkVO+JLP6NRyQH0mHQQ==,type:str]
+    FORCED_PREMIUMIZE_API_KEY: ENC[AES256_GCM,data:z1GVuqKMN6osvXDxtWeNXw==,iv:C85OPnBimAG50YMJba1eFISJjOPG9i1LBNaqIqxOovM=,tag:5AoEPHjTxUp4REFms/F+6A==,type:str]
 sops:
     age:
         - recipient: age1hvmdhkt8llkq3m00ullewwgycy2ujr8tlhqk6ley07usyexcq9vsz8mymh
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBVTUh3cjMvTUhkZzRYNHBH
-            Q2RUZkREeTAwOFVhU21kOU5TbGM3bGhjVlY0CmdHOUxJaEJ4d1orV1F4djM4bnR1
-            OUlsVXFKME9vY2JlR1hpYXl3bnpDQWMKLS0tIDNMYnVWSHRKTXFjOHU0Q3pnS21s
-            dmhDNlprSS81eS9RSjlHZVd3cHhMVlEKRHR7Mh9INymcyKuOdjFwDsxjvkj5bNk1
-            6KKrBTPdvlR9X6o0HaRiYEp5mVQnGOoTQxkHryE3d3kTVZQH/NxROQ==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBQRFJOMFpGSGZDYW10YUVj
+            TEF4aUVQSHhQV0pVVWY5QnIyVXh0UDJIY3lBCnlZRTZ0a0dRSGtxVTJJQVUxbzVD
+            aWFzcGpQbGVJYjY4QVVTTHlnbjQxUGcKLS0tIE1xT1NrejQvbnYwS2FvZ1pEazJr
+            N2tOc1FGZWY3clVIVWxqN3dBc2t6NTgKwGe6Y66AnQLQP114NuGEAoLTp0YfSfMs
+            kYmYjOu5DU/v8vj1z0yyizU3l2/ldWjB2SaJFOpD7vHtI4UjpZBipA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-04-12T09:56:55Z"
-    mac: ENC[AES256_GCM,data:0wYO/C6hRv+Kp1x6pdyET1hQU9b1Y4zqkHkgoNjeMFxLbXg1skC2mPmukaiMvZwpbTfLGX2KZ0QbL0QcVm1zg9GhB0OYPnPGnWzJVTTpQxTdj7snXTUjiQC3PuuoeAwXGx44/Uf1h+NRLtVCMe6QjEdAvohywPk+LEbgmVx9ghg=,iv:nLZo65LD2sAJJl1I9CqR6ABNTqS9th5EBTXphJvacnA=,tag:NgK02F9Ed2CA8PfPAzTuZQ==,type:str]
+    lastmodified: "2026-04-12T10:24:29Z"
+    mac: ENC[AES256_GCM,data:xHP8dqhch2s0exgcoIiIhoGzkjbR1i1QP9ajrc5v7pH4z/t1QQCGizpyBIfSRVaHu2eUIoIKkTWoubSEa65UxH5pcWlXfiOc+lsuGXI2tAJSAEFf6KdlMkcDLDMR2leFYQn+T0BbB9KXXYSr8aprzvedvugHdp2/2Zhks/J6nQk=,iv:cfPuYfdrU1ktSL/JqnO5j8B2dmIctvxfZaRaYOkTwf8=,tag:+SdgXfFTTDskJRrkrVBAMw==,type:str]
     encrypted_regex: ^(data|stringData)$
     version: 3.12.2


### PR DESCRIPTION
## Summary
- Adds `FORCED_PREMIUMIZE_API_KEY` to the AIOStreams SOPS-encrypted secret
- Enables Premiumize as a debrid service alongside Real Debrid

## Test plan
- [ ] Verify the pod restarts successfully with the new env var
- [ ] Confirm Premiumize is available as a debrid option in the configure UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)