### PR TITLE
feat: add NzbDAV WebDAV server deployment

### DIFF
--- a/apps/eniac/kustomization.yaml
+++ b/apps/eniac/kustomization.yaml
@@ -26,3 +26,4 @@ resources:
   - plex.yaml
   - aiostreams-secret.yaml
   - aiostreams.yaml
+  - nzbdav.yaml

--- a/apps/eniac/nzbdav.yaml
+++ b/apps/eniac/nzbdav.yaml
@@ -1,0 +1,60 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: nzbdav
+  namespace: media
+spec:
+  interval: 5m
+  chart:
+    spec:
+      chart: app-template
+      version: 4.6.2
+      sourceRef:
+        kind: HelmRepository
+        name: bjw-s-labs
+        namespace: media
+  values:
+    controllers:
+      main:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          main:
+            image:
+              repository: nzbdav/nzbdav
+              tag: latest
+            env:
+              TZ: Europe/London
+              PUID: "1000"
+              PGID: "1000"
+    service:
+      main:
+        ports:
+          http:
+            port: 3000
+    ingress:
+      main:
+        enabled: true
+        className: traefik
+        annotations:
+          cert-manager.io/cluster-issuer: letsencrypt
+        hosts:
+          - host: nzbdav.home.gawbul.io
+            paths:
+              - path: /
+                service:
+                  identifier: main
+                  port: http
+        tls:
+          - hosts:
+              - nzbdav.home.gawbul.io
+            secretName: nzbdav-tls
+    persistence:
+      config:
+        enabled: true
+        storageClass: local-path
+        accessMode: ReadWriteOnce
+        size: 2Gi
+        globalMounts:
+          - path: /config


### PR DESCRIPTION
## Summary
- Add NzbDAV deployment to the media namespace using the bjw-s app-template Helm chart
- Exposes NzbDAV at `nzbdav.home.gawbul.io` with Traefik ingress and Let's Encrypt TLS
- Persistent volume for `/config` to retain Usenet provider settings and WebDAV credentials

## Test plan
- [ ] Verify FluxCD reconciles the new HelmRelease successfully
- [ ] Confirm NzbDAV web UI is accessible at `https://nzbdav.home.gawbul.io`
- [ ] Configure Usenet provider and WebDAV credentials via the web UI
- [ ] Test streaming content through AIOStreams/Stremio

🤖 Generated with [Claude Code](https://claude.com/claude-code)