### PR TITLE
fix: bump Seerr chart version to 3.5.1

### DIFF
--- a/apps/eniac/seerr.yaml
+++ b/apps/eniac/seerr.yaml
@@ -19,7 +19,7 @@ spec:
   chart:
     spec:
       chart: seerr-chart
-      version: 3.2.0
+      version: 3.5.1
       sourceRef:
         kind: HelmRepository
         name: seerr


### PR DESCRIPTION
## Summary
- Bumps Seerr Helm chart version from 3.2.0 to 3.5.1
- Resolves issue where Seerr UI was still showing version 3.1.0 due to outdated chart reference

## Test plan
- [ ] Verify FluxCD reconciles the HelmRelease successfully: `flux get helmrelease seerr -n media`
- [ ] Confirm Seerr UI reports the updated version

🤖 Generated with [Claude Code](https://claude.com/claude-code)