### PR TITLE
fix: disable frr-k8s subchart to unblock MetalLB 0.16.0

### DIFF
--- a/infrastructure/controllers/metallb.yaml
+++ b/infrastructure/controllers/metallb.yaml
@@ -31,3 +31,10 @@ spec:
         name: metallb
         namespace: metallb-system
       interval: 1h
+  values:
+    frrk8s:
+      enabled: false
+    frr-k8s:
+      prometheus:
+        serviceMonitor:
+          enabled: false


### PR DESCRIPTION
## Summary
- MetalLB HelmRelease was stuck failing on chart 0.16.0 with `nil pointer evaluating interface {}.serviceMonitor` from the bundled `frr-k8s` subchart
- We use L2 mode and don't need `frr-k8s`, so disable it at the parent (`frrk8s.enabled: false`) and also set `frr-k8s.prometheus.serviceMonitor.enabled: false` to defuse the subchart's nil-deref directly (subchart templates render regardless of the parent toggle)
- Unblocks `infra-controllers` Kustomization, which was blocking `infra-configs`, `infra-ingress`, `infra-notifications`, `apps`, and `apps-config`

## Test plan
- [ ] After merge, watch `flux get helmrelease metallb -n metallb-system` reach Ready
- [ ] Confirm `flux get kustomizations -A` shows `infra-controllers` and downstream Kustomizations Ready
- [ ] Verify existing LoadBalancer services still have their assigned IPs from the 192.168.50.204-254 pool

🤖 Generated with [Claude Code](https://claude.com/claude-code)